### PR TITLE
[FIX] make invoice_residual a non-stored computed field

### DIFF
--- a/sale_ext_sst/__manifest__.py
+++ b/sale_ext_sst/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Extension for sales functions',
-    'version': '11.0.1.2.0',
+    'version': '11.0.1.2.1',
     'author': 'Quartile Limited',
     'website': 'https://www.quartile.co',
     'category': 'Sale',

--- a/sale_ext_sst/models/sale_order.py
+++ b/sale_ext_sst/models/sale_order.py
@@ -15,19 +15,23 @@ class SaleOrder(models.Model):
     requested_date = fields.Datetime(
         readonly=False,
     )
+    #this field is decided to be a non-stored computed field to avoid the
+    #complication of the logic and the risk of missing a trigger.
+    #reconciling/unreconciling invoice with an existing payment particularly
+    #didn't seem to provide the necessary info in context.
     invoice_residual = fields.Monetary(
         'Invoice Amount Due',
         compute='_compute_invoice_residual',
-        store=True,
         help='Remaining amount due of invoice(s).',
     )
 
-    @api.multi
-    @api.depends('invoice_ids.residual')
     def _compute_invoice_residual(self):
-        for order in self:
+        for order in self.filtered(lambda r: r.state in ['sale', 'done']):
             order.invoice_residual = order.amount_total
-            for invoice in order.invoice_ids:
-                if invoice.state not in ('draft', 'cancel'):
-                    order.invoice_residual -= invoice.amount_total \
-                                              - invoice.residual
+            if order.invoice_ids:
+                #we do not cover refund invoices (origin != order.name) here
+                #(it is out of scope)
+                order.invoice_residual -= sum(order.invoice_ids.\
+                    filtered(lambda r: r.origin == order.name and
+                                       r.state in ['open', 'paid']).\
+                    mapped(lambda r: r.amount_total - r.residual))


### PR DESCRIPTION
The original logic/design had some issues:
- when `residual` of an invoice (customer/supplier) is changed, all invoice_residual of all the SOs is recalculated, which would tremendously slow down invoice operation
- not enough triggers specified in "depends". e.g. change in SO itself wouldn't trigger update of `invoice_residual`
- having more triggers would complicate the logic. i.e. separate logic would be needed for SO update, invoice update and payment reconciliation
- particularly, when payment is reconciled/unreconciled, Odoo did not seem to provide enough info for updating `invoice_residual` (more research is needed)
- refund cases were not considered (the value would be wrong when there is a refund)

Therefore, to simplify the logic, we have decided to make `invoice_residual` a non-stored field. Refund cases are made out of scope of `invoice_residual` calculation.