### PR TITLE
Update sales product list view

### DIFF
--- a/product_ext_sst/__manifest__.py
+++ b/product_ext_sst/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Extension for product',
-    'version': '11.0.1.3.0',
+    'version': '11.0.1.3.1',
     'author': 'Quartile Limited',
     'website': 'https://www.quartile.co',
     'category': 'Product',

--- a/product_ext_sst/views/product_template_views.xml
+++ b/product_ext_sst/views/product_template_views.xml
@@ -85,6 +85,7 @@
                 <field name="standard_price"/>
                 <field name="auction_start_price"/>
                 <field name="auction_buyout_price"/>
+                <field name="list_price"/>
                 <field name="carrier_id"/>
                 <field name="carrier_size_id"/>
                 <field name="delivery_cites"/>

--- a/product_yahoo_auction_sst/__manifest__.py
+++ b/product_yahoo_auction_sst/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Products\' Yahoo Auction information',
-    'version': '11.0.1.1.0',
+    'version': '11.0.1.1.1',
     'author': 'Quartile Limited',
     'website': 'https://www.quartile.co',
     'category': 'Product',

--- a/product_yahoo_auction_sst/models/product_template.py
+++ b/product_yahoo_auction_sst/models/product_template.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import models, fields, api
+from odoo.addons import decimal_precision as dp
 
 
 class ProductTemplate(models.Model):
@@ -29,11 +30,13 @@ class ProductTemplate(models.Model):
         'hr.employee',
         string='Staff in charge',
     )
-    auction_start_price = fields.Monetary(
+    auction_start_price = fields.Float(
         string='Auction Starting Price',
+        digits=dp.get_precision('Product Price'),
     )
-    auction_buyout_price = fields.Monetary(
+    auction_buyout_price = fields.Float(
         string='Auction Buyout Price',
+        digits=dp.get_precision('Product Price'),
     )
     product_condition = fields.Selection(
         [('new', 'New'), ('used', 'Used')],

--- a/product_yahoo_auction_sst/views/product_template_views.xml
+++ b/product_yahoo_auction_sst/views/product_template_views.xml
@@ -18,8 +18,8 @@
                             <field name="staff_in_charge"/>
                         </group>
                         <group>
-                            <field name="auction_start_price"/>
-                            <field name="auction_buyout_price"/>
+                            <field name="auction_start_price" widget='monetary'/>
+                            <field name="auction_buyout_price" widget='monetary'/>
                             <field name="product_condition"/>
                             <field name="carrier_id"/>
                             <field name="carrier_size_id"/>


### PR DESCRIPTION
- Show list_price in sales product list view
- Adjust definitions of `auction_start_price` and `auction_buyout_price` to be consistent with standard price/cost fields (i.e. make them float fields instead of monetary)